### PR TITLE
side_bar:last-message

### DIFF
--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -18,4 +18,4 @@
             .leftcontent__leftmain__groups__group__group-name
               = group.name
             .leftcontent__leftmain__groups__group__last-message          
-              -# = group.show_last_message
+              = group.show_last_message


### PR DESCRIPTION
what
グループの最新メッセージの表示
why
機能実装のため