### PR TITLE
group.user.name list

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -7,7 +7,8 @@
         %ul.maincontent__header__leftbox__box__group-member-list
           %p Member :
           %li.maincontent__header__leftbox__box__group-member-list__member
-            
+            -@group.users.each do |user|
+              = user.name
     .maincontent__header__edit
       = link_to 'Edit', edit_group_path(@group.id), class: "edit-btn" 
           


### PR DESCRIPTION
what
chat-headerのgroup-user-listのユーザー名の表示
why
グループのユーザーを表示する機能追加